### PR TITLE
dev -> prod controller environment 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
     depends_on:
       - iofog-connector
     environment:
-      - NODE_ENV=development
+      - NODE_ENV=production
     ports:
-      - "51121:51121"
+      - "54421:54421"
     links:
       - iofog-connector
     container_name: iofog-controller

--- a/iofog-agent/config.xml
+++ b/iofog-agent/config.xml
@@ -2,7 +2,7 @@
 <config>
 	<access_token/>
 	
-	<controller_url>http://iofog-controller:51121/api/v3/</controller_url>
+	<controller_url>http://iofog-controller:54421/api/v3/</controller_url>
 
 	<controller_cert>/etc/iofog-agent/cert.crt</controller_cert>
 	

--- a/iofog-agent/start.sh
+++ b/iofog-agent/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-CONTROLLER_HOST="http://iofog-controller:51121/api/v3"
+CONTROLLER_HOST="http://iofog-controller:54421/api/v3"
 
 token=""
 uuid=""

--- a/iofog-controller/start.sh
+++ b/iofog-controller/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-CONTROLLER_HOST="http://localhost:51121/api/v3"
+CONTROLLER_HOST="http://localhost:54421/api/v3"
 
 iofog-controller start
 if [ -f /first_run.tmp ]; then


### PR DESCRIPTION
dev -> prod controller environment in order to avoid SQL CLI output in quickstart project

this one should be merged after https://github.com/ioFog/Controller/pull/379 which temporary disables email activation by default in config for production and after https://github.com/ioFog/iofog.org/pull/13