### PR TITLE
fixed connector update for some versions

### DIFF
--- a/iofog-connector/Dockerfile
+++ b/iofog-connector/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update -qq
+RUN apt-get update --fix-missing -qq
 RUN apt-get install -qqy sudo
 RUN apt-get install -qqy curl
 RUN apt-get install -qqy software-properties-common


### PR DESCRIPTION
there's an issue with 1.0.0 connector package size in packagecloud which may cause an error during build with non-matching package size in cache & packagecloud, this one will fix it